### PR TITLE
ability to use a block for tab_for when using a custom builder

### DIFF
--- a/lib/tabs_on_rails/tabs.rb
+++ b/lib/tabs_on_rails/tabs.rb
@@ -38,8 +38,8 @@ module TabsOnRails
       end                                                 # end
     end
     
-    def method_missing(*args)
-      @builder.tab_for(*args)
+    def method_missing(*args, &block)
+      @builder.tab_for(*args, &block)
     end
 
     def render(&block)


### PR DESCRIPTION
Title pretty much says it all. Thanks for the great plugin. Here's how I'm using this:

def tab_for(tab, name, options, item_options = {}, &block)
  item_options[:class] = item_options[:class].to_s.split(" ").push("active").join(" ") if current_tab?(tab)
  content = @context.link_to(name, options)
  content += @context.capture(&block) if block_given?
  @context.content_tag(:li, content, item_options)
end
