### PR TITLE
a way to set default builder

### DIFF
--- a/lib/tabs_on_rails/tabs.rb
+++ b/lib/tabs_on_rails/tabs.rb
@@ -15,9 +15,12 @@ module TabsOnRails
 
   class Tabs
 
+    mattr_accessor :default_builder
+    @@default_builder = TabsBuilder
+
     def initialize(context, options = {})
       @context = context
-      @builder = (options.delete(:builder) || TabsBuilder).new(@context, options)
+      @builder = (options.delete(:builder) || self.class.default_builder).new(@context, options)
       @options = options
     end
 

--- a/test/unit/tabs_test.rb
+++ b/test/unit/tabs_test.rb
@@ -43,6 +43,17 @@ class TabsTest < ActionView::TestCase
     assert_instance_of builder, @tabs.instance_variable_get(:"@builder")
   end
 
+  def test_initialize_with_default_builder
+    default_builder = TabsOnRails::Tabs.default_builder
+    TabsOnRails::Tabs.default_builder = CustomBuilder
+
+    custom_tab = TabsOnRails::Tabs.new(@template) # doesnt need argument :builder => CustomBuilder
+
+    assert_instance_of CustomBuilder, custom_tab.instance_variable_get(:"@builder")
+
+    TabsOnRails::Tabs.default_builder = default_builder
+  end
+
 
   def test_open_tabs
     assert_equal '<ul>', @tabs.open_tabs
@@ -89,6 +100,23 @@ class TabsTest < ActionView::TestCase
     end
 
     assert_dom_equal expected, result
+  end
+
+  class CustomBuilder < TabsOnRails::Tabs::Builder
+    def open_tabs(options = {})
+      @context.tag("ul", options, open = true)
+    end
+
+    def close_tabs(options = {})
+      "</ul>".html_safe
+    end
+
+    def tab_for(tab, name, options, item_options = {})
+      item_options[:class] = (current_tab?(tab) ? 'active' : '')
+      @context.content_tag(:li, item_options) do
+        @context.link_to(name, options)
+      end
+    end
   end
 
 end


### PR DESCRIPTION
Hi Weppos

  Thank you created the amazing gem, it's very useful when generating menus, but in my website, I need a custom builder and call tabs_tag many times, it is repeated passing same argument like :builder => CustomBuilder, so I add a commit to implement this.

  With this feature, we don't need adding argument like :builder => CustomBuilder on tabs_tag any more, just note we need put the custom_builder.rb into config/initializers because rails won't load that by default.

  let me know please if something wrong :)
