### PR TITLE
Added option 'current_tab_as_link' to have current tab as link

### DIFF
--- a/lib/tabs_on_rails/tabs/tabs_builder.rb
+++ b/lib/tabs_on_rails/tabs/tabs_builder.rb
@@ -38,8 +38,9 @@ module TabsOnRails
       # Implements Builder#tab_for.
       #
       def tab_for(tab, name, url_options, item_options = {})
+        current_tab_as_link = item_options.delete(:current_tab_as_link)
         item_options[:class] = item_options[:class].to_s.split(" ").push(@options[:active_class] || "current").join(" ") if current_tab?(tab)
-        content = @context.link_to_unless(current_tab?(tab), name, url_options) do
+        content = @context.link_to_unless(current_tab?(tab) && !current_tab_as_link, name, url_options) do
           @context.content_tag(:span, name)
         end
         @context.content_tag(:li, content, item_options)

--- a/test/dummy.rb
+++ b/test/dummy.rb
@@ -8,7 +8,7 @@ require "rails/railtie"
 class Dummy
   Routes = ActionDispatch::Routing::RouteSet.new
   Routes.draw do
-    match ':controller(/:action(/:id))'
+    get ':controller(/:action(/:id))'
   end
 end
 

--- a/test/unit/tabs/tabs_builder_test.rb
+++ b/test/unit/tabs/tabs_builder_test.rb
@@ -42,6 +42,13 @@ class TabsBuilderTest < ActionView::TestCase
                      @builder.tab_for(:dashboard, 'Foo Dashboard', '#')
   end
 
+  def test_tab_for_should_return_link_if_current_tab_and_current_tab_as_link_is_true
+    assert_dom_equal %Q{<li class="current"><a href="#">Dashboard</a></li>},
+                     @builder.tab_for(:dashboard, 'Dashboard', '#', current_tab_as_link: true)
+    assert_dom_equal %Q{<li class="current"><a href="#">Foo Dashboard</a></li>},
+                     @builder.tab_for(:dashboard, 'Foo Dashboard', '#', current_tab_as_link: true)
+  end
+
   def test_tab_for_with_options_as_uri
     assert_dom_equal %Q{<li><a href="http://welcome.com/">Foo Bar</a></li>},
                      @builder.tab_for(:welcome, 'Foo Bar', 'http://welcome.com/')


### PR DESCRIPTION
Hi,

Appreciations for writing this gem. :) It helped us.

We had a requirement to show the current tab also as link enabling users to navigate using the current tab too. I felt this might be a common requirement and introduced 'current_tab_as_link' link item option.

Have a look and lemme know what you think about.
