### PR TITLE
String.new instead of string literal

### DIFF
--- a/lib/tabs_on_rails/tabs.rb
+++ b/lib/tabs_on_rails/tabs.rb
@@ -54,7 +54,7 @@ module TabsOnRails
       open_tabs_options  = options.delete(:open_tabs)  || {}
       close_tabs_options = options.delete(:close_tabs) || {}
 
-      "".tap do |html|
+      String.new.tap do |html|
         html << open_tabs(open_tabs_options).to_s
         html << @context.capture(self, &block)
         html << close_tabs(close_tabs_options).to_s


### PR DESCRIPTION
This is to address deprecated warning message.

> gems/tabs_on_rails-3.0.0/lib/tabs_on_rails/tabs.rb:58: warning: literal string will be frozen in the future (run with --debug-frozen-string-literal for more information)